### PR TITLE
docs: update agent docs for Hugo stack, drop stale eslint hook

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -2,22 +2,23 @@
 
 ## Netlify
 
-- **Build command**: `pnpm docs:build`
-- **Publish directory**: `docs/.vuepress/dist`
+- **Build command**: `hugo`
+- **Publish directory**: `public`
+- **Hugo version**: pinned via `HUGO_VERSION` in `netlify.toml` (`[build.environment]`)
 - **Auto-deploy**: push to main branch
-- **Security headers**: configured in `netlify.toml`
+- **Security headers**: configured in `netlify.toml` — never weaken them
+- **Redirects**: `netlify.toml` also handles HTTPS/www canonicalization and legacy `.html` → clean-URL redirects
 
 ## Pre-deploy Checklist
 
-- `pnpm run lint:fix`
-- `pnpm docs:build` (local)
-- `pnpm run security:check`
-- Verify content renders correctly in dev mode
+- `hugo` builds cleanly (local)
+- `pnpm test` (Playwright e2e) passes
+- Verify content renders correctly with `hugo server`
 
 ## Dependencies (Renovate)
 
 - Minor/patch: auto-merged after 3 days
-- Major: manual review required (7 day wait)
-- VuePress packages: grouped to avoid peer dependency issues
+- Major: manual review required — Hugo majors wait 7 days
+- Hugo pin in `netlify.toml` is updated by a custom Renovate regex manager
 - Security fixes: auto-merged immediately
 - Lock file: automated updates

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -3,44 +3,38 @@
 ## Commands
 
 ```bash
-pnpm install               # install dependencies
-pnpm run docs:dev          # dev server at http://localhost:8080
-pnpm run docs:build        # build static site → docs/.vuepress/dist
-pnpm run lint              # lint
-pnpm run lint:fix          # lint + auto-fix
-pnpm run typecheck         # type check (no emit)
-pnpm run test              # Playwright e2e (headless)
+hugo server                # dev server at http://localhost:1313 (live reload)
+hugo                       # build static site → public/
+pnpm install               # install Playwright test dependencies
+pnpm test                  # Playwright e2e (builds site, serves public/ on :8080)
 pnpm run test:ui           # interactive test UI
 pnpm run test:headed       # tests with browser visible
 pnpm run test:debug        # step through with Playwright Inspector
-pnpm run security:audit    # dependency audit (moderate)
-pnpm run security:check    # high-severity only
-pnpm run security:fix      # attempt auto-fix
-pnpm run security:trivy    # Trivy filesystem scan
-pnpm run security:trivy:secrets  # scan for exposed secrets
-pnpm run security:trivy:config   # scan config files
 ```
+
+Local Hugo should match the `HUGO_VERSION` pin in `netlify.toml`.
 
 ## Common Tasks
 
-**Add/update content**: Edit `docs/*.md` → test with `docs:dev` → commit (Netlify auto-deploys)
+**Add/update content**: Edit `content/*.md` → check with `hugo server` → commit (Netlify auto-deploys)
 
-**Modify config**: Edit `docs/.vuepress/config.js` → restart dev server → test build
+**Modify site config or nav**: Edit `hugo.toml` → `hugo server` picks it up on reload
 
-**Add static assets**: Place in `docs/.vuepress/public/` → reference as `/filename.ext` in Markdown
+**Change templates**: Edit `layouts/` (`index.html`, `404.html`, `_default/single.html`, `_default/baseof.html`)
 
-**Update dependencies**: `pnpm update` → `pnpm install` → test locally → `security:check`
+**Styling**: Edit `static/css/style.css`
 
-**Styling**: Edit via VuePress theme config or `docs/.vuepress/styles/`
+**Add static assets**: Place in `static/` → referenced from the site root (e.g. `static/images/foo.png` → `/images/foo.png`)
+
+**Update dependencies**: Renovate handles this, including the Hugo pin in `netlify.toml` — only intervene for majors or failures
 
 ## Troubleshooting
 
 **Build fails**:
-1. Check Node version matches `package.json` engines field
-2. Clear cache: `rm -rf docs/.vuepress/.cache docs/.vuepress/.temp`
-3. Reinstall: `rm -rf node_modules && pnpm install` (only delete `pnpm-lock.yaml` if it's actually corrupted)
-4. Check lint errors: `pnpm run lint`
+1. Check local Hugo version against `HUGO_VERSION` in `netlify.toml`
+2. Run `hugo` locally and read the error — template errors name the offending layout file
+3. For test failures: `rm -rf node_modules && pnpm install` (only delete `pnpm-lock.yaml` if it's actually corrupted)
 
-**Dev server issues**: Kill port 8080, clear VuePress cache dirs, restart
+**Dev server issues**: Kill port 1313 and restart `hugo server`; Playwright's test server uses port 8080
 
-**Netlify failures**: Check build logs → verify build command/publish dir → confirm Netlify is installing `devDependencies` (it does by default; only an issue if install flags explicitly skip them) → test build locally
+**Netlify failures**: Check build logs → verify build command is `hugo` and publish dir is `public` → confirm `HUGO_VERSION` in `netlify.toml` is valid → reproduce with the same Hugo version locally

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,3 @@ repos:
     args: ['--maxkb=1000']
   - id: mixed-line-ending
   - id: detect-private-key
-- repo: local
-  hooks:
-  - id: eslint
-    name: eslint
-    entry: pnpm exec eslint
-    language: system
-    types: [javascript, jsx, ts, tsx, vue]
-    pass_filenames: true
-    require_serial: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,35 @@
 # peterdemirdjiancom
 
-Personal portfolio/resume website. VuePress 2.0, Vue 3, pnpm, deployed to Netlify.
+Personal portfolio/resume website. Hugo static site, deployed to Netlify. Node/pnpm is used only for Playwright e2e tests.
 
 ## Constraints
 
 - **License**: CC-BY-NC-ND-4.0 — never modify content for redistribution or commercial use
-- **VuePress RC**: On 2.0.0-rc.x — verify compatibility before any major changes
+- **Hugo version**: Pinned via `HUGO_VERSION` in `netlify.toml` — keep local Hugo in sync; major bumps require manual review and testing
 - **Professional tone**: Never add casual or unprofessional content
 - **Security**: Never remove or weaken security headers in `netlify.toml`
-- **Dependencies**: Renovate handles routine updates — don't manually bump versions unless necessary; major version bumps require testing
+- **Dependencies**: Renovate handles routine updates (including the Hugo pin) — don't manually bump versions unless necessary
 
 ## Conventions
 
-- ES modules only (`import`/`export`) — never `var`, never CommonJS
-- Vue 3 Composition API for any new components
-- pnpm only — never npm or yarn
-- Run `pnpm run lint:fix` before committing
-- Run `pnpm run security:check` after dependency changes
-- Test locally with `pnpm run docs:dev` before suggesting changes
+- Content is Markdown in `content/`; templates are Hugo layouts in `layouts/`
+- Styling lives in `static/css/style.css` — no CSS framework, no preprocessor
+- pnpm only — never npm or yarn (Playwright is the only Node dependency)
+- Test locally with `hugo server` before suggesting changes
+- Run `pnpm test` (Playwright e2e) before committing site changes
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `docs/.vuepress/config.js` | VuePress config, navbar, theme |
-| `docs/.vuepress/client.ts` | Client-side config (dynamic year) |
-| `docs/README.md` | Home page |
-| `docs/resume.md` | Resume/CV |
-| `netlify.toml` | Deployment + security headers |
-| `eslint.config.js` | Linting rules |
-| `package.json` | Dependencies, scripts, Node/pnpm version constraints |
+| `hugo.toml` | Site config, params, nav menus |
+| `content/_index.md` | Home page |
+| `content/resume.md` | Resume/CV |
+| `content/license.md` | License page |
+| `layouts/` | Hugo templates (`index.html`, `404.html`, `_default/`) |
+| `static/css/style.css` | Site styles |
+| `static/images/` | Static assets, served at `/images/` |
+| `netlify.toml` | Build command, `HUGO_VERSION` pin, security headers, redirects |
+| `tests/` + `playwright.config.ts` | Playwright e2e tests |
+| `package.json` | Playwright deps, Node/pnpm version constraints |
 | `renovate.json` | Automated dependency updates |


### PR DESCRIPTION
## What changed

- **AGENTS.md** (symlinked as `CLAUDE.md`, `.cursorrules`, `.windsurfrules`): rewritten for the Hugo stack — `hugo.toml` site config, `content/` pages, `layouts/` templates, `static/css/style.css` styles, and Playwright as the only remaining Node/pnpm usage. Replaced the VuePress RC constraint with the `HUGO_VERSION` pin in `netlify.toml`.
- **.claude/rules/deployment.md**: build command is `hugo`, publish dir is `public`, pre-deploy checklist is `hugo` build + `pnpm test` + visual check with `hugo server`. Renovate section now reflects the actual config (Hugo majors get 7-day manual review; the Hugo pin is updated via a custom regex manager).
- **.claude/rules/dev-workflow.md**: commands, common tasks, and troubleshooting now reference `hugo server` (port 1313), `hugo`, and the four Playwright scripts that actually exist in `package.json`. Notes that `pnpm test` builds the site itself and serves `public/` on port 8080.
- **.pre-commit-config.yaml**: removed the local `eslint` hook (and its now-empty `repo: local` block).

## Why

These docs still described the pre-migration VuePress/Node stack — `docs/.vuepress/config.js`, `pnpm docs:dev`/`docs:build`, eslint, and VuePress RC constraints that no longer exist after the Hugo migration (`docs/superpowers/plans/2026-06-19-hugo-migration.md`). The eslint pre-commit hook was missed in that migration's cleanup: eslint is no longer a devDependency and has no config file, so the hook fails on any staged JS/TS file (e.g. `scripts/sarif-formatter.js`, `tests/*.spec.ts`).

## Notes for reviewers

- Still-valid constraints were kept: CC-BY-NC-ND-4.0 license, professional tone, never weaken `netlify.toml` security headers, Renovate handles dependency updates.
- All facts were checked against the current repo state (`netlify.toml`, `hugo.toml`, `package.json`, `renovate.json`, `playwright.config.ts`, CI workflow) rather than carried over.
- Docs + config only; no site content or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)