### PR TITLE
Redesign site with a professional visual identity and copy

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "hugo-dev",
+      "runtimeExecutable": "hugo",
+      "runtimeArgs": ["server", "--port", "1313", "--noHTTPCache"],
+      "port": 1313
+    }
+  ]
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,6 +4,10 @@ title: "Pete Demirdjian"
 
 ## About Me
 
-I'm a Principal DevOps Engineer currently working at Cargurus building out a cloud for me to angrily yell at while we list cars!
-
-![picture-of-me](/images/home.png)
+<div class="about-grid">
+<div class="about-text">
+<p>I'm a Principal DevOps Engineer at <a href="https://www.cargurus.com" rel="noopener" target="_blank">CarGurus</a>, where I architect a self-service infrastructure platform built on HCP Terraform and AWS — governed by policy as code so engineering teams can provision and manage their own cloud resources safely and autonomously.</p>
+<p>Before CarGurus, I spent over five years at Wayfair across cloud engineering and site reliability, driving Terraform adoption, configuration management at scale, and self-service tooling for developers. I care about paved roads, pragmatic automation, and mentoring engineers to own their infrastructure.</p>
+</div>
+<img src="/images/home.png" alt="picture-of-me" class="about-photo">
+</div>

--- a/content/license.md
+++ b/content/license.md
@@ -2,28 +2,26 @@
 title: "License"
 ---
 
-# License
-
 ## Creative Commons License
 
 This website and its content are licensed under the **Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License**.
 
 <a rel="license" href="https://creativecommons.org/licenses/by-nc-nd/4.0/">
-  <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" />
+  <img alt="Creative Commons License" class="cc-badge" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" />
 </a>
 
 ## What this means
 
-### ✅ You are free to:
+### You are free to:
 - **Share** — copy and redistribute the material in any medium or format
 - The licensor cannot revoke these freedoms as long as you follow the license terms
 
-### ⚠️ Under the following terms:
+### Under the following terms:
 - **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
 - **NonCommercial** — You may not use the material for commercial purposes.
 - **NoDerivatives** — If you remix, transform, or build upon the material, you may not distribute the modified material.
 
-### ❌ No additional restrictions
+### No additional restrictions
 You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
 
 ## Source Code vs. Content
@@ -45,13 +43,8 @@ If you share or reference content from this website, please include:
 
 ## Contact
 
-For questions about usage rights or permission requests beyond this license, please contact:
-
-**Peter Demirdjian**
-📧 [code@peterdemirdjian.com](mailto:code@peterdemirdjian.com)
+For questions about usage rights or permission requests beyond this license, please contact [code@peterdemirdjian.com](mailto:code@peterdemirdjian.com).
 
 ## Full License Text
 
-For the complete legal text, visit: [https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode](https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode)
-
----
+For the complete legal text, visit [creativecommons.org/licenses/by-nc-nd/4.0/legalcode](https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode).

--- a/content/resume.md
+++ b/content/resume.md
@@ -4,33 +4,17 @@ title: "Resume"
 
 ## Contact Info
 
-| :email: [code@peterdemirdjian.com](mailto:code@peterdemirdjian.com)| :phone: (857) 895-2304  |
-| :---------------------: |:--------------:|
+<p class="contact-row">
+  <a href="mailto:code@peterdemirdjian.com">code@peterdemirdjian.com</a>
+  <span>(857) 895-2304</span>
+  <a href="https://www.linkedin.com/in/peter-demirdjian/" rel="noopener" target="_blank">linkedin.com/in/peter-demirdjian</a>
+</p>
 
-## Education
+## Experience
 
-### Northeastern University
-**Boston, MA**
-* Bachelor of Science, Business Administration, Computer Science (Minor) (Aug 2018)
+### CarGurus, Inc
 
-## Skills
-
-* **Cloud & Orchestration:** AWS (EC2, S3, Redis, IAM), GCP, Kubernetes (EKS), Nomad
-* **Infrastructure as Code:** **Self-Service Infrastructure Platform Design**, HCP Terraform, Terraform, Sentinel (Policy as Code), Puppet, Packer, Consul
-* **CI/CD & DevEx:** **AI-Assisted Infrastructure Development**, Concourse CI/CD, Jenkins, GitHub Actions, Artifactory, Buildkite, Octopus Deploy
-* **Networking & Security:** HAProxy (Canary LBs, Traffic Mirroring), Cyera (Data Discovery), Sentinel, SSL/TLS Management
-* **Programming & Automation:** Golang, Python, PowerShell, PHP, Ruby, SQL
-* **Leadership & Strategy:** Cloud Enablement, Agile/Scrum (Scrum Leader), RFC/ADR Authoring, Mentorship & Coaching, Cost Optimization, Vendor Management
-
-### Notable Open Source & Projects
-* [peterdemirdjian.com](https://github.com/pdemirdjian/peterdemirdjiancom) - Full-stack website with automated CI/CD and visual testing.
-* [Golang: Buildkite Agent PR](https://github.com/buildkite/agent/pull/1122) - Enabled native PowerShell support.
-* [HCL: Packer Custom Image](https://github.com/pdemirdjian/infra/blob/main/images/itsademergency_com_nginx.pkr.hcl) - Custom image with built-in healthchecks.
-* [Advent of Code](https://github.com/pdemirdjian/adventofcode21) - Algorithmic problem solving in Golang.
-
-## CarGurus, Inc
-
-### _Principal DevOps Engineer_ - October 2024 - PRESENT
+#### Principal DevOps Engineer <span class="dates">October 2024 – Present</span>
 
 * Architected a self-service infrastructure platform using HCP Terraform, AWS, and GitHub, governed by Sentinel Policy as Code to enable autonomous resource management.
 * Championed AI-driven workflows to assist developers in generating compliant AWS code, removing centralized bottlenecks while ensuring safety and speed.
@@ -45,7 +29,7 @@ title: "Resume"
 * Contributed to organizational growth by serving on interview panels for partner companies (e.g., CarOffer).
 * Recognized as a primary troubleshooter for complex, cross-domain outages, rapidly orienting in unfamiliar systems to drive root cause resolution.
 
-### _Senior DevOps Engineer_ - January 2022 - October 2024
+#### Senior DevOps Engineer <span class="dates">January 2022 – October 2024</span>
 
 * Stabilized and optimized Concourse CI/CD by architecting a graceful node retirement process and implementing autoscaling with spot instances, saving ~$30k/month.
 * Implemented S3 Lifecycle policies for Snowplow and Static assets, resulting in combined savings of over $28k/month.
@@ -55,9 +39,9 @@ title: "Resume"
 * Championed a collaborative culture by actively onboarding and mentoring new hires, significantly accelerating their ramp-up time on complex systems.
 * Drove architectural consensus by authoring RFCs and documentation (e.g., Concourse improvement plan), ensuring knowledge transfer and democratizing decisions.
 
-## Wayfair LLC
+### Wayfair LLC
 
-### _Senior Cloud Engineer_ - October 2020 - January 2022
+#### Senior Cloud Engineer <span class="dates">October 2020 – January 2022</span>
 
 * Consultation with developer teams to drive cloud adoption and migration from our on premise datacenter.
 * Develop Terraform modules to enable and accelerate features available in Open Source Terraform and Terraform Enterprise.
@@ -66,7 +50,7 @@ title: "Resume"
 * Created a team Golang utility to assist with troubleshooting, day to day operations, and oncall.
 * Deployed Datadog monitoring scripts for observability into our most critical cloud resources running the storefront.
 
-### _Senior Site Reliability Engineer_ - August 2017 - October 2020
+#### Senior Site Reliability Engineer <span class="dates">August 2017 – October 2020</span>
 
 * Created complete configuration management roles and profiles within Puppet for windows and linux based machines.
 * Build out Buildkite agent infrastructure, create Buildkite plugins, and contribute code into open source Buildkite Agent.
@@ -79,16 +63,16 @@ title: "Resume"
 * Optimize Windows License Placement to save $3Mil in Annual Spend.
 * Empowered teammates to learn latest technology (Puppet, Terraform) with careful reviews, constructive feedback, and peer-coding sessions.
 
-### _IT Support Engineer_ - June 2016 - August 2017
+#### IT Support Engineer <span class="dates">June 2016 – August 2017</span>
 
 * Created self service Jenkins pipeline that allowed users to request software via System Center Configuration Manager that employed internal change control APIs to require manager approval to keep software licensing costs down and reduce ticket load for frontline IT members.
 * Developed, maintained, and improved internal inventory system in PHP for tracking equipment in multiple locations.
 * Managed users and computers through Active Directory, Group Policy, and System Center Configuration Manager with 7000+ users.
 * Configured Linux virtual machines on various data center and office hypervisors to run the Casper Application to support Mac OS X in such a way that they conform to company-maintained security policies.
 
-### _IT Intern_ - January 2014 - June 2016
+#### IT Intern <span class="dates">January 2014 – June 2016</span>
 
-* Imaged and configured workstations using SCCM for weekly new hire cohorts ranging in size from 25- 150 new hires.
+* Imaged and configured workstations using SCCM for weekly new hire cohorts ranging in size from 25–150 new hires.
 * Ensured equipment was ready and available for employees and conference rooms.
 * Branded certain conference room experience and equipment to align with a newly launched brand.
 * Followed code deployment processes and guidelines to write and implement Powershell scripts to send automated email reminders for a variety of IT, HR, and Facilities use cases.
@@ -96,4 +80,24 @@ title: "Resume"
 * Maintained, installed, and repaired computer and network hardware as needed.
 * Automated base IT functions for other IT staff to utilize in their daily functions.
 
----
+## Skills
+
+* **Cloud & Orchestration:** AWS (EC2, S3, Redis, IAM), GCP, Kubernetes (EKS), Nomad
+* **Infrastructure as Code:** Self-Service Infrastructure Platform Design, HCP Terraform, Terraform, Sentinel (Policy as Code), Puppet, Packer, Consul
+* **CI/CD & DevEx:** AI-Assisted Infrastructure Development, Concourse CI/CD, Jenkins, GitHub Actions, Artifactory, Buildkite, Octopus Deploy
+* **Networking & Security:** HAProxy (Canary LBs, Traffic Mirroring), Cyera (Data Discovery), Sentinel, SSL/TLS Management
+* **Programming & Automation:** Golang, Python, PowerShell, PHP, Ruby, SQL
+* **Leadership & Strategy:** Cloud Enablement, Agile/Scrum (Scrum Leader), RFC/ADR Authoring, Mentorship & Coaching, Cost Optimization, Vendor Management
+
+## Selected Projects & Open Source
+
+* [Volume-Price Analysis MCP Server](https://github.com/pdemirdjian/volume-price-analysis) — Python MCP server that gives AI assistants volume-price analysis tools for stock market data (OBV, VWAP, Volume Profile, MFI, and more).
+* **Homelab** — Three-node k3s Kubernetes cluster managed entirely as code: Ansible host bootstrap, Kustomize and Helm workloads, GPU-scheduled local LLM serving, distributed storage, full monitoring stack, and a Flux CD GitOps pipeline.
+* [peterdemirdjian.com](https://github.com/pdemirdjian/peterdemirdjiancom) — Full-stack website with automated CI/CD and visual testing.
+* [Golang: Buildkite Agent PR](https://github.com/buildkite/agent/pull/1122) — Enabled native PowerShell support.
+
+## Education
+
+### Northeastern University <span class="dates">August 2018</span>
+
+* Bachelor of Science, Business Administration, Computer Science (Minor) — Boston, MA

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,10 @@
 {{ define "main" }}
-<h1>404 – Page Not Found</h1>
-<p>The page you're looking for doesn't exist.</p>
-<p><a href="/">Return home</a></p>
+<section class="hero">
+  <p class="eyebrow">404</p>
+  <h1>Page not found</h1>
+  <p class="lede">The page you're looking for doesn't exist or has moved.</p>
+  <div class="hero-actions">
+    <a class="btn btn-primary" href="/">Return home</a>
+  </div>
+</section>
 {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,10 @@
   <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   <meta name="twitter:image" content="{{ .Site.Params.ogImage | absURL }}">
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700;800&display=swap">
+
   <link rel="icon" href="/images/favicon.ico">
   <link rel="stylesheet" href="/css/style.css">
   <script>
@@ -29,6 +33,23 @@
       document.documentElement.classList.add(isDark ? 'dark' : 'light');
     })();
   </script>
+  {{ if .IsHome }}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Peter Demirdjian",
+    "alternateName": "Pete Demirdjian",
+    "jobTitle": "Principal DevOps Engineer",
+    "worksFor": { "@type": "Organization", "name": "CarGurus" },
+    "alumniOf": { "@type": "CollegeOrUniversity", "name": "Northeastern University" },
+    "url": "{{ .Site.BaseURL }}",
+    "image": "{{ .Site.Params.ogImage | absURL }}",
+    "email": "mailto:code@peterdemirdjian.com",
+    "sameAs": ["https://www.linkedin.com/in/peter-demirdjian/"]
+  }
+  </script>
+  {{ end }}
 </head>
 <body>
   <header>
@@ -67,16 +88,10 @@
     {{ block "main" . }}{{ end }}
   </main>
   <footer>
-    <div style="margin-bottom: 0.5rem;">
-      © {{ now.Format "2006" }} Peter Demirdjian. Licensed under
-      <a href="/license/" style="color: #3b82f6; text-decoration: none;">CC BY-NC-ND 4.0</a>.
-    </div>
-    <div>
-      <a rel="license noopener" href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">
-        <img alt="Creative Commons License" style="border-width:0; height: 20px; border-radius: 0; margin: 0.5rem auto 0;"
-             src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" />
-      </a>
-    </div>
+    <p>
+      © {{ now.Format "2006" }} Peter Demirdjian · Licensed under
+      <a rel="license" href="/license/">CC BY-NC-ND 4.0</a>
+    </p>
   </footer>
 </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
 <article>
+  <h1>{{ .Title }}</h1>
   {{ .Content }}
 </article>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,13 @@
 {{ define "main" }}
-<div class="home-hero">
-  <h1>{{ .Site.Title }}</h1>
-  <p class="home-tagline">Made by Pete Demirdjian with ❤️</p>
-</div>
+<section class="hero">
+  <p class="eyebrow">Principal DevOps Engineer</p>
+  <h1>Pete Demirdjian</h1>
+  <p class="lede">I build self-service infrastructure platforms — paved roads that let engineering teams ship to the cloud quickly and safely.</p>
+  <div class="hero-actions">
+    <a class="btn btn-primary" href="/resume/">View resume</a>
+    <a class="btn" href="https://www.linkedin.com/in/peter-demirdjian/" rel="noopener" target="_blank">LinkedIn</a>
+    <a class="btn" href="mailto:code@peterdemirdjian.com">Email me</a>
+  </div>
+</section>
 {{ .Content }}
 {{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,73 +1,86 @@
 *, *::before, *::after { box-sizing: border-box; }
 
-/* ── Light theme (default) ───────────────────────────────────────────────── */
+/* ── Design tokens ────────────────────────────────────────────────────────
+   Light theme (default). Fonts: Archivo for display, system stack for body,
+   monospace as the utility voice (labels, dates, nav). */
 :root {
-  --color-bg:         #ffffff;
-  --color-bg-header:  #ffffff;
-  --color-bg-th:      #f6f8fa;
-  --color-text:       #2c3e50;
-  --color-text-muted: #6b7280;
-  --color-border:     #eaecef;
-  --color-link:       #3eaf7c;
-  --color-link-footer:#3b82f6;
+  --color-bg:          #f7f9fc;
+  --color-surface:     #ffffff;
+  --color-border:      #dce4ef;
+  --color-text:        #172a41;
+  --color-text-muted:  #55677f;
+  --color-accent:      #0b7c6c;
+  --color-accent-soft: #0b7c6c1a;
+  --color-on-accent:   #ffffff;
+
+  --font-display: 'Archivo', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
 }
 
 /* ── Dark theme — OS preference ──────────────────────────────────────────── */
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg:         #0d1117;
-    --color-bg-header:  #161b22;
-    --color-bg-th:      #21262d;
-    --color-text:       #e6edf3;
-    --color-text-muted: #8b949e;
-    --color-border:     #30363d;
-    --color-link:       #58a6ff;
-    --color-link-footer:#79c0ff;
+    --color-bg:          #0d1522;
+    --color-surface:     #141f31;
+    --color-border:      #253651;
+    --color-text:        #e7edf6;
+    --color-text-muted:  #90a2bc;
+    --color-accent:      #41c9ae;
+    --color-accent-soft: #41c9ae1f;
+    --color-on-accent:   #06251e;
   }
 }
 
 /* ── Dark theme — manual override via .dark on <html> ───────────────────── */
 html.dark {
-  --color-bg:         #0d1117;
-  --color-bg-header:  #161b22;
-  --color-bg-th:      #21262d;
-  --color-text:       #e6edf3;
-  --color-text-muted: #8b949e;
-  --color-border:     #30363d;
-  --color-link:       #58a6ff;
-  --color-link-footer:#79c0ff;
+  --color-bg:          #0d1522;
+  --color-surface:     #141f31;
+  --color-border:      #253651;
+  --color-text:        #e7edf6;
+  --color-text-muted:  #90a2bc;
+  --color-accent:      #41c9ae;
+  --color-accent-soft: #41c9ae1f;
+  --color-on-accent:   #06251e;
 }
 
 /* ── Force light when explicitly chosen ─────────────────────────────────── */
 html.light {
-  --color-bg:         #ffffff;
-  --color-bg-header:  #ffffff;
-  --color-bg-th:      #f6f8fa;
-  --color-text:       #2c3e50;
-  --color-text-muted: #6b7280;
-  --color-border:     #eaecef;
-  --color-link:       #3eaf7c;
-  --color-link-footer:#3b82f6;
+  --color-bg:          #f7f9fc;
+  --color-surface:     #ffffff;
+  --color-border:      #dce4ef;
+  --color-text:        #172a41;
+  --color-text-muted:  #55677f;
+  --color-accent:      #0b7c6c;
+  --color-accent-soft: #0b7c6c1a;
+  --color-on-accent:   #ffffff;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: var(--font-body);
   font-size: 16px;
-  line-height: 1.6;
+  line-height: 1.65;
   color: var(--color-text);
   background: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
 }
 
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ── Header / navigation ─────────────────────────────────────────────────── */
 header {
   border-bottom: 1px solid var(--color-border);
-  height: 60px;
-  display: flex;
-  align-items: center;
   padding: 0 1.5rem;
   position: sticky;
   top: 0;
-  background: var(--color-bg-header);
+  background: color-mix(in srgb, var(--color-bg) 85%, transparent);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
   z-index: 100;
 }
 
@@ -75,125 +88,295 @@ nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
   width: 100%;
-  max-width: 960px;
+  max-width: 860px;
   margin: 0 auto;
+  min-height: 60px;
+  padding: 0.5rem 0;
 }
 
 .site-title {
-  font-weight: 600;
-  font-size: 1.1rem;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
   color: var(--color-text);
   text-decoration: none;
+  white-space: nowrap;
 }
+
+.site-title:hover { color: var(--color-accent); text-decoration: none; }
 
 nav ul {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
-  gap: 1.25rem;
+  gap: 1.4rem;
   flex-wrap: wrap;
   align-items: center;
 }
 
 nav ul a {
-  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.9rem;
+  transition: color 0.15s;
 }
 
-nav ul a:hover { color: var(--color-link); }
+nav ul a:hover { color: var(--color-accent); text-decoration: none; }
 
 /* ── Dark-mode toggle button ─────────────────────────────────────────────── */
 #theme-toggle {
   background: none;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  color: var(--color-text);
+  color: var(--color-text-muted);
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.95rem;
   line-height: 1;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3rem 0.55rem;
   display: flex;
   align-items: center;
   transition: border-color 0.15s, color 0.15s;
 }
 
 #theme-toggle:hover {
-  border-color: var(--color-link);
-  color: var(--color-link);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
+/* ── Layout ──────────────────────────────────────────────────────────────── */
 main {
-  max-width: 960px;
+  max-width: 860px;
   margin: 0 auto;
-  padding: 2rem 1.5rem;
+  padding: 2rem 1.5rem 3.5rem;
 }
 
-h1, h2, h3 {
+/* ── Typography ──────────────────────────────────────────────────────────── */
+h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 2.1rem;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 1.5rem 0 0.75rem;
+}
+
+/* Section labels: the monospace "spec sheet" voice, ruled off to the right */
+h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  font-family: var(--font-mono);
   font-weight: 600;
-  line-height: 1.25;
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin: 3rem 0 1.25rem;
 }
 
-h1 { font-size: 2rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.5rem; }
-h2 { font-size: 1.5rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3rem; }
-h3 { font-size: 1.1rem; }
+h2::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
 
-a { color: var(--color-link); text-decoration: none; }
+h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  margin: 2.25rem 0 0.5rem;
+}
+
+h4 {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.25rem;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.02rem;
+  margin: 1.5rem 0 0.4rem;
+}
+
+.dates {
+  font-family: var(--font-mono);
+  font-weight: 400;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+a { color: var(--color-accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+
+em { color: var(--color-text-muted); }
 
 table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
 th, td { border: 1px solid var(--color-border); padding: 0.5rem 1rem; text-align: left; }
-th { background: var(--color-bg-th); }
+th { background: var(--color-surface); }
 
-ul, ol { padding-left: 1.5rem; }
-li { margin: 0.25rem 0; }
+ul, ol { padding-left: 1.4rem; margin: 0.5rem 0 1.25rem; }
+li { margin: 0.3rem 0; }
+li::marker { color: var(--color-accent); }
+
+blockquote {
+  margin: 1rem 0;
+  padding: 0.25rem 1.25rem;
+  border-left: 3px solid var(--color-accent);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+}
 
 img { max-width: 100%; height: auto; display: block; margin: 1rem auto; }
 
-.home-hero {
-  text-align: center;
-  padding: 2rem 0 1rem;
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 2rem;
-}
-
-.home-hero h1 {
-  font-size: 2.5rem;
-  border-bottom: none;
-  padding-bottom: 0;
-  margin-bottom: 0.5rem;
-}
-
-.home-tagline {
-  color: var(--color-text-muted);
-  font-size: 1.1rem;
-  margin: 0;
-}
-
-img[alt="picture-of-me"] {
-  max-width: 300px;
-  width: 100%;
-}
-
 hr { border: none; border-top: 1px solid var(--color-border); margin: 2rem 0; }
 
+/* ── Home: hero ──────────────────────────────────────────────────────────── */
+.hero {
+  padding: 3.5rem 0 2.75rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin: 0 0 1rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  font-weight: 800;
+  margin: 0 0 1rem;
+}
+
+.lede {
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+  max-width: 36em;
+  margin: 0 0 1.75rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.6rem 1.15rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  background: var(--color-surface);
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.btn:hover {
+  text-decoration: none;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.btn-primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+.btn-primary:hover {
+  background: color-mix(in srgb, var(--color-accent) 85%, var(--color-text));
+  color: var(--color-on-accent);
+}
+
+/* ── Home: about ─────────────────────────────────────────────────────────── */
+.about-grid {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.about-text p { margin: 0 0 1rem; }
+
+img.about-photo,
+img[alt="picture-of-me"] {
+  width: 100%;
+  max-width: 300px;
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+}
+
+/* ── Resume ──────────────────────────────────────────────────────────────── */
+.contact-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  margin: 0 0 1rem;
+}
+
+.contact-row span { color: var(--color-text-muted); }
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
 footer {
   border-top: 1px solid var(--color-border);
   text-align: center;
   padding: 2rem 1.5rem;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--color-text-muted);
 }
 
-footer a { color: var(--color-link-footer); }
+footer p { margin: 0; }
 
-@media (max-width: 640px) {
-  nav ul { gap: 0.75rem; }
-  nav { flex-wrap: wrap; height: auto; padding: 0.75rem 0; }
-  header { height: auto; }
-  h1 { font-size: 1.5rem; }
+footer a { color: var(--color-accent); }
+
+/* ── License page ────────────────────────────────────────────────────────── */
+img.cc-badge { margin: 1rem 0; border-radius: 0; }
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 700px) {
+  nav { flex-wrap: wrap; justify-content: center; text-align: center; }
+  nav ul { gap: 0.9rem 1.1rem; justify-content: center; }
+  .hero { padding: 2.5rem 0 2rem; }
+  .about-grid { grid-template-columns: 1fr; }
+  img.about-photo, img[alt="picture-of-me"] { margin: 0 auto; }
+  h4 .dates { flex-basis: 100%; }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition: none !important; }
+}
+
+/* ── Print (resume-friendly) ─────────────────────────────────────────────── */
+@media print {
+  header, footer, .hero-actions, #theme-toggle { display: none; }
+  body { background: #fff; color: #000; font-size: 12px; }
+  main { max-width: none; padding: 0; }
+  h2, .eyebrow { color: #000; }
+  a { color: #000; text-decoration: none; }
+  .dates { color: #333; }
 }

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -18,7 +18,7 @@ test.describe('Mobile Responsiveness', () => {
     
     // Check main content is visible on mobile
     await expect(page.locator('h1').first()).toBeVisible()
-    // Check navigation links are accessible
-    await expect(page.getByRole('link', { name: 'Resume' })).toBeVisible()
+    // Check navigation links are accessible - use first() to handle duplicates
+    await expect(page.getByRole('link', { name: 'Resume' }).first()).toBeVisible()
   })
 })


### PR DESCRIPTION
## What changed

**Design system** (`static/css/style.css`, layouts)
- Replaced the default-markdown look with an intentional system: Archivo for display type (Google Fonts, already permitted by the CSP), monospace "spec label" section headings and dates, a teal accent, and matched light/dark themes (OS preference + manual toggle preserved).
- Home page now opens with a hero (eyebrow, name, positioning statement, Resume/LinkedIn/Email buttons) and an about section with the photo framed beside the text.
- Resume renders as a structured document: roles as rows with right-aligned monospace dates, plus a print stylesheet so it prints like an actual resume.
- License and 404 pages restyled to match; footer simplified to a text CC BY-NC-ND link.
- Added JSON-LD Person schema on the home page.

**Copy**
- Home: replaced casual copy ("angrily yell at", "with ❤️") with a professional summary grounded in the resume.
- Resume: all bullets preserved verbatim; sections reordered to Contact → Experience → Skills → Projects → Education; emoji contact table replaced with a clean contact row; en-dashes and "Present" casing fixed.
- Projects: added [Volume-Price Analysis MCP Server](https://github.com/pdemirdjian/volume-price-analysis) and a homelab entry (described without a link since that repo is private); removed Advent of Code and the Packer image link that 404s.

**Tests / tooling**
- `tests/mobile.spec.ts`: added `.first()` to the Resume-link assertion — the new hero "View resume" button also matches the role selector (same pattern the other specs already use).
- Added `.claude/launch.json` for launching the Hugo dev server from Claude Code's preview pane.

## Why

The site previously rendered as unstyled GitHub-flavored markdown with some informal copy; this makes it read as a professional portfolio/resume.

## Reviewer notes

- Security headers in `netlify.toml` are untouched.
- Full Playwright suite passes (67 passed, 3 skipped) and `hugo --gc --minify` builds clean.
- Content judgment calls worth a look: the rewritten About paragraphs, resume section order, and the homelab project description (kept at stack level, no hostnames/topology/secrets tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)