### PR TITLE
docs: add Site operations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The website's source code (build scripts, configuration files, etc.) may be refe
 
 For questions about usage rights, please contact [code@peterdemirdjian.com](mailto:code@peterdemirdjian.com).
 
+## Site operations
+
+Routine maintenance of this repository is orchestrated by kandev running on a home Mac mini. Agent-generated changes are never pushed directly — every change lands through a pull request and is reviewed by a human before merge.
+
 ---
 
 © 2025 Peter Demirdjian. Licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/).


### PR DESCRIPTION
## Summary

Adds a short "Site operations" section at the end of README.md (before the copyright footer) documenting how this repository is maintained:

- Routine maintenance is orchestrated by **kandev** running on a home Mac mini.
- Agent-generated changes are never pushed directly — every change lands through a pull request and is reviewed by a human before merge.

This explains to contributors and reviewers why automated PRs appear in this repo and what the review guarantee is. Docs-only change; README.md is not part of the published Hugo site.

## Validation

- [x] Section is 2 sentences, matches README tone and `##` heading formatting
- [x] File hygiene verified (UTF-8, LF, final newline, no trailing whitespace)
- [x] `hugo` builds cleanly with v0.164.0 (matches `HUGO_VERSION` pin); README.md confirmed absent from `public/`
- [x] No test impact — Playwright e2e only exercises the built site

## Checklist

- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)