### PR TITLE
test: add dark-mode, license, and 404 e2e tests; fix vacuous assertion (PET-14)

### DIFF
--- a/tests/404.spec.ts
+++ b/tests/404.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('404 Page', () => {
+  test('should show 404 content for unknown routes', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist-at-all/')
+    await expect(page.locator('h1')).toContainText('404')
+    await expect(page.locator('body')).toContainText("Page Not Found")
+  })
+
+  test('should provide a link back to the home page', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist-at-all/')
+    const homeLink = page.getByRole('link', { name: /Return home/i })
+    await expect(homeLink).toBeVisible()
+    await homeLink.click()
+    await expect(page).toHaveURL('/')
+  })
+})

--- a/tests/license.spec.ts
+++ b/tests/license.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('License Page', () => {
+  test('should load license page with correct title', async ({ page }) => {
+    await page.goto('/license/')
+    await expect(page).toHaveTitle(/License/)
+  })
+
+  test('should display CC BY-NC-ND 4.0 license content', async ({ page }) => {
+    await page.goto('/license/')
+    const bodyText = await page.locator('body').textContent()
+    expect(bodyText).toContain('Creative Commons')
+    expect(bodyText).toContain('Attribution-NonCommercial-NoDerivatives')
+    expect(bodyText).toContain('4.0')
+  })
+
+  test('should have a link to the CC license', async ({ page }) => {
+    await page.goto('/license/')
+    await expect(
+      page.getByRole('link', { name: /CC BY-NC-ND 4\.0/i }).first()
+    ).toBeVisible()
+  })
+
+  test('should have a return path from navbar', async ({ page }) => {
+    await page.goto('/license/')
+    await expect(page.getByRole('link', { name: 'License' }).first()).toBeVisible()
+  })
+})

--- a/tests/resume.spec.ts
+++ b/tests/resume.spec.ts
@@ -14,10 +14,10 @@ test.describe('Resume Page', () => {
 
   test('should have contact information', async ({ page }) => {
     await page.goto('/resume/')
-    
-    // Check for email or LinkedIn (common resume elements)
-    const hasContactInfo = await page.locator('body').textContent()
-    expect(hasContactInfo).toBeTruthy()
+
+    const bodyText = await page.locator('body').textContent()
+    expect(bodyText).toContain('code@peterdemirdjian.com')
+    expect(bodyText).toContain('(857) 895-2304')
   })
 
   test('should navigate from home to resume', async ({ page }) => {

--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Dark Mode', () => {
+  test('clicking toggle flips dark/light class on html element', async ({ page }) => {
+    await page.goto('/')
+
+    const initialIsDark = await page.evaluate(() =>
+      document.documentElement.classList.contains('dark')
+    )
+
+    await page.click('#theme-toggle')
+
+    const afterIsDark = await page.evaluate(() =>
+      document.documentElement.classList.contains('dark')
+    )
+    const afterIsLight = await page.evaluate(() =>
+      document.documentElement.classList.contains('light')
+    )
+
+    expect(afterIsDark).toBe(!initialIsDark)
+    expect(afterIsLight).toBe(initialIsDark)
+  })
+
+  test('theme persists as dark across page reload via localStorage', async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.setItem('theme', 'dark'))
+    await page.reload()
+
+    await expect(page.locator('html')).toHaveClass(/\bdark\b/)
+    await expect(page.locator('html')).not.toHaveClass(/\blight\b/)
+  })
+
+  test('theme persists as light across page reload via localStorage', async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.setItem('theme', 'light'))
+    await page.reload()
+
+    await expect(page.locator('html')).toHaveClass(/\blight\b/)
+    await expect(page.locator('html')).not.toHaveClass(/\bdark\b/)
+  })
+
+  test('toggle button is visible and accessible', async ({ page }) => {
+    await page.goto('/')
+    const toggle = page.locator('#theme-toggle')
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-label', /toggle dark mode/i)
+  })
+
+  test('clicking toggle twice returns to original theme', async ({ page }) => {
+    await page.goto('/')
+
+    const before = await page.evaluate(() =>
+      document.documentElement.classList.contains('dark')
+    )
+
+    await page.click('#theme-toggle')
+    await page.click('#theme-toggle')
+
+    const after = await page.evaluate(() =>
+      document.documentElement.classList.contains('dark')
+    )
+
+    expect(after).toBe(before)
+  })
+})


### PR DESCRIPTION
## Summary

- **theme.spec.ts** (5 tests): covers `#theme-toggle` class flip (dark↔light on `<html>`), localStorage persistence across page reload (both dark and light), `aria-label` presence, and round-trip double-toggle. Tests are structured so they fail if the toggle script is removed — clicking the button won't flip the class without the handler.
- **license.spec.ts** (4 tests): verifies `/license/` loads with correct title, contains CC BY-NC-ND 4.0 content, has a link to the CC license, and the navbar License link is present.
- **404.spec.ts** (2 tests): verifies unknown routes render "404 – Page Not Found" content and the "Return home" link navigates back to `/`.
- **resume.spec.ts** (fix): replaces the vacuous `expect(body).toBeTruthy()` assertion with concrete checks for `code@peterdemirdjian.com` and `(857) 895-2304` from `content/resume.md`.

## Test plan

- [x] All 24 tests pass on Chromium (`pnpm test --project=chromium`): 24 passed, 1 skipped (pre-existing)
- [x] Tests run against a live Hugo build via `serve`, covering real rendered output
- [x] Theme persistence tests use `localStorage.setItem` + `page.reload()` to verify the init script applies stored preference on load
- [x] Dark-mode toggle test would fail if `#theme-toggle`'s click handler were removed (class would not change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)